### PR TITLE
make livegrep works with databricks github

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -105,7 +105,7 @@ func (s *server) ServeSearch(ctx context.Context, w http.ResponseWriter, r *http
 
 func (s *server) ServeFile(ctx context.Context, w http.ResponseWriter, r *http.Request) {
 	repoName := r.URL.Query().Get(":repo")
-	path := pat.Tail("/view/:repo/", r.URL.Path)
+	path := pat.Tail("/view/databricks/:repo/", r.URL.Path)
 	commit := r.URL.Query().Get("commit")
 	if commit == "" {
 		commit = "HEAD"
@@ -116,9 +116,10 @@ func (s *server) ServeFile(ctx context.Context, w http.ResponseWriter, r *http.R
 		return
 	}
 
-	repo, ok := s.repos[repoName]
+	fmt.Println("Finding ", repoName, "in repos: ", s.repos)
+	repo, ok := s.repos["databricks/" + repoName]
 	if !ok {
-		http.Error(w, "No such repo", 404)
+		http.Error(w, "No such repo: " + repoName, 404)
 		return
 	}
 
@@ -291,7 +292,7 @@ func New(cfg *config.Config) (http.Handler, error) {
 	m.Add("GET", "/debug/stats", srv.Handler(srv.ServeStats))
 	m.Add("GET", "/search/:backend", srv.Handler(srv.ServeSearch))
 	m.Add("GET", "/search/", srv.Handler(srv.ServeSearch))
-	m.Add("GET", "/view/:repo/", srv.Handler(srv.ServeFile))
+	m.Add("GET", "/view/databricks/:repo/", srv.Handler(srv.ServeFile))
 	m.Add("GET", "/about", srv.Handler(srv.ServeAbout))
 	m.Add("GET", "/help", srv.Handler(srv.ServeHelp))
 	m.Add("GET", "/opensearch.xml", srv.Handler(srv.ServeOpensearch))

--- a/web/src/fileview/fileview.js
+++ b/web/src/fileview/fileview.js
@@ -20,7 +20,7 @@ function getSelectedText() {
 function getFileInfo() {
   // Disassemble the current URL.
   var path = window.location.pathname.slice(6); // Strip "/view/" prefix
-  var repoName = path.split('/')[0];
+  var repoName = path.split('/')[0] + '/' + path.split('/')[1];
   var pathInRepo = path.slice(repoName.length + 1).replace(/^\/+/, '');
 
   return {

--- a/web/webpack.config.js
+++ b/web/webpack.config.js
@@ -37,6 +37,6 @@ module.exports = {
   },
 
   plugins: [
-    new webpack.optimize.UglifyJsPlugin()
+    // new webpack.optimize.UglifyJsPlugin()
   ]
 }


### PR DESCRIPTION
Original file browser cannot handle multi level repository names, so:

    Hardcode the "databricks" prefix into livegrep's file browser URL patterns
    Also hardcode the second level path in frontend to make the external link (to Github) work
